### PR TITLE
Redis 문제 관련 작업

### DIFF
--- a/be/src/main/java/buddyguard/mybuddyguard/config/RedisConfig.java
+++ b/be/src/main/java/buddyguard/mybuddyguard/config/RedisConfig.java
@@ -1,5 +1,9 @@
 package buddyguard.mybuddyguard.config;
 
+import com.fasterxml.jackson.annotation.JsonAutoDetect;
+import com.fasterxml.jackson.annotation.PropertyAccessor;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
 import java.time.Duration;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
@@ -39,8 +43,12 @@ public class RedisConfig {
         RedisTemplate<String, Object> redisTemplate = new RedisTemplate<>();
         redisTemplate.setConnectionFactory(connectionFactory);
 
+        // 메타정보 제거를 위해 ObjectMapper 따로 선언
+        ObjectMapper objectMapper = new ObjectMapper();
+        objectMapper.deactivateDefaultTyping();
+
         redisTemplate.setKeySerializer(new StringRedisSerializer());
-        redisTemplate.setValueSerializer(new GenericJackson2JsonRedisSerializer());
+        redisTemplate.setValueSerializer(new GenericJackson2JsonRedisSerializer(objectMapper));
 
         return redisTemplate;
     }

--- a/be/src/main/java/buddyguard/mybuddyguard/config/RedisConfig.java
+++ b/be/src/main/java/buddyguard/mybuddyguard/config/RedisConfig.java
@@ -44,6 +44,7 @@ public class RedisConfig {
 
         redisTemplate.setKeySerializer(new StringRedisSerializer());
         redisTemplate.setValueSerializer(new GenericJackson2JsonRedisSerializer(objectMapper));
+        redisTemplate.setEnableTransactionSupport(true);
 
         return redisTemplate;
     }
@@ -62,6 +63,7 @@ public class RedisConfig {
 
         redisTemplate.setKeySerializer(new StringRedisSerializer());
         redisTemplate.setValueSerializer(serializer);
+        redisTemplate.setEnableTransactionSupport(true);
 
         return redisTemplate;
     }

--- a/be/src/main/java/buddyguard/mybuddyguard/config/RedisConfig.java
+++ b/be/src/main/java/buddyguard/mybuddyguard/config/RedisConfig.java
@@ -1,6 +1,6 @@
 package buddyguard.mybuddyguard.config;
 
-import buddyguard.mybuddyguard.invitation.entity.InvitationInformation;
+import buddyguard.mybuddyguard.invitation.repository.dto.StoredInvitationInformation;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import java.time.Duration;
 import org.springframework.beans.factory.annotation.Value;
@@ -49,16 +49,16 @@ public class RedisConfig {
     }
 
     @Bean
-    public RedisTemplate<String, InvitationInformation> invitationRedisTemplate(
+    public RedisTemplate<String, StoredInvitationInformation> invitationRedisTemplate(
             LettuceConnectionFactory connectionFactory) {
-        RedisTemplate<String, InvitationInformation> redisTemplate = new RedisTemplate<>();
+        RedisTemplate<String, StoredInvitationInformation> redisTemplate = new RedisTemplate<>();
         redisTemplate.setConnectionFactory(connectionFactory);
 
         ObjectMapper objectMapper = new ObjectMapper();
         objectMapper.deactivateDefaultTyping();
 
-        Jackson2JsonRedisSerializer<InvitationInformation> serializer =
-                new Jackson2JsonRedisSerializer<>(objectMapper, InvitationInformation.class);
+        Jackson2JsonRedisSerializer<StoredInvitationInformation> serializer =
+                new Jackson2JsonRedisSerializer<>(objectMapper, StoredInvitationInformation.class);
 
         redisTemplate.setKeySerializer(new StringRedisSerializer());
         redisTemplate.setValueSerializer(serializer);

--- a/be/src/main/java/buddyguard/mybuddyguard/config/RedisConfig.java
+++ b/be/src/main/java/buddyguard/mybuddyguard/config/RedisConfig.java
@@ -8,17 +8,14 @@ import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
 import org.springframework.data.redis.connection.RedisStandaloneConfiguration;
 import org.springframework.data.redis.connection.lettuce.LettuceClientConfiguration;
 import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+import org.springframework.data.redis.core.RedisKeyValueAdapter.EnableKeyspaceEvents;
+import org.springframework.data.redis.core.RedisKeyValueAdapter.ShadowCopy;
+import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.data.redis.repository.configuration.EnableRedisRepositories;
+import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSerializer;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
 
 @Configuration
-@EnableJpaRepositories(basePackages = {"buddyguard.mybuddyguard.hospital",
-        "buddyguard.mybuddyguard.login", "buddyguard.mybuddyguard.pet",
-        "buddyguard.mybuddyguard.weight", "buddyguard.mybuddyguard.walk", 
-        "buddyguard.mybuddyguard.alert", "buddyguard.mybuddyguard.walkimage",
-        "buddyguard.mybuddyguard.vaccination", "buddyguard.mybuddyguard.feed"})
-@EnableRedisRepositories(basePackages = {"buddyguard.mybuddyguard.invitation",
-        "buddyguard.mybuddyguard.weight", "buddyguard.mybuddyguard.walk",
-        "buddyguard.mybuddyguard.alert",  "buddyguard.mybuddyguard.jwt"})
 public class RedisConfig {
 
     @Value("${spring.data.redis.host}")
@@ -35,5 +32,16 @@ public class RedisConfig {
                 .build();
         return new LettuceConnectionFactory(new RedisStandaloneConfiguration(redisHost, redisPort),
                 clientConfig);
+    }
+
+    @Bean
+    public RedisTemplate<String, Object> redisTemplate(LettuceConnectionFactory connectionFactory) {
+        RedisTemplate<String, Object> redisTemplate = new RedisTemplate<>();
+        redisTemplate.setConnectionFactory(connectionFactory);
+
+        redisTemplate.setKeySerializer(new StringRedisSerializer());
+        redisTemplate.setValueSerializer(new GenericJackson2JsonRedisSerializer());
+
+        return redisTemplate;
     }
 }

--- a/be/src/main/java/buddyguard/mybuddyguard/config/RedisConfig.java
+++ b/be/src/main/java/buddyguard/mybuddyguard/config/RedisConfig.java
@@ -1,22 +1,17 @@
 package buddyguard.mybuddyguard.config;
 
-import com.fasterxml.jackson.annotation.JsonAutoDetect;
-import com.fasterxml.jackson.annotation.PropertyAccessor;
+import buddyguard.mybuddyguard.invitation.entity.InvitationInformation;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.SerializationFeature;
 import java.time.Duration;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
 import org.springframework.data.redis.connection.RedisStandaloneConfiguration;
 import org.springframework.data.redis.connection.lettuce.LettuceClientConfiguration;
 import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
-import org.springframework.data.redis.core.RedisKeyValueAdapter.EnableKeyspaceEvents;
-import org.springframework.data.redis.core.RedisKeyValueAdapter.ShadowCopy;
 import org.springframework.data.redis.core.RedisTemplate;
-import org.springframework.data.redis.repository.configuration.EnableRedisRepositories;
 import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSerializer;
+import org.springframework.data.redis.serializer.Jackson2JsonRedisSerializer;
 import org.springframework.data.redis.serializer.StringRedisSerializer;
 
 @Configuration
@@ -49,6 +44,24 @@ public class RedisConfig {
 
         redisTemplate.setKeySerializer(new StringRedisSerializer());
         redisTemplate.setValueSerializer(new GenericJackson2JsonRedisSerializer(objectMapper));
+
+        return redisTemplate;
+    }
+
+    @Bean
+    public RedisTemplate<String, InvitationInformation> invitationRedisTemplate(
+            LettuceConnectionFactory connectionFactory) {
+        RedisTemplate<String, InvitationInformation> redisTemplate = new RedisTemplate<>();
+        redisTemplate.setConnectionFactory(connectionFactory);
+
+        ObjectMapper objectMapper = new ObjectMapper();
+        objectMapper.deactivateDefaultTyping();
+
+        Jackson2JsonRedisSerializer<InvitationInformation> serializer =
+                new Jackson2JsonRedisSerializer<>(objectMapper, InvitationInformation.class);
+
+        redisTemplate.setKeySerializer(new StringRedisSerializer());
+        redisTemplate.setValueSerializer(serializer);
 
         return redisTemplate;
     }

--- a/be/src/main/java/buddyguard/mybuddyguard/invitation/entity/InvitationInformation.java
+++ b/be/src/main/java/buddyguard/mybuddyguard/invitation/entity/InvitationInformation.java
@@ -6,9 +6,7 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.springframework.data.annotation.Id;
-import org.springframework.data.redis.core.RedisHash;
 
-@RedisHash(value = "invitation", timeToLive = 3600L)
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
 @Getter
@@ -18,4 +16,14 @@ public class InvitationInformation {
     private String id;
     private Long petId;
     private Long userId;
+    private Long timeToLive;
+
+    public static InvitationInformation create(String uuid, Long petId, Long userId) {
+        return InvitationInformation.builder()
+                .id(uuid)
+                .petId(petId)
+                .userId(userId)
+                .timeToLive(3600L)
+                .build();
+    }
 }

--- a/be/src/main/java/buddyguard/mybuddyguard/invitation/mapper/InvitationMapper.java
+++ b/be/src/main/java/buddyguard/mybuddyguard/invitation/mapper/InvitationMapper.java
@@ -1,0 +1,18 @@
+package buddyguard.mybuddyguard.invitation.mapper;
+
+import buddyguard.mybuddyguard.invitation.entity.InvitationInformation;
+import buddyguard.mybuddyguard.invitation.repository.dto.StoredInvitationInformation;
+import java.time.Instant;
+import java.util.Date;
+
+public class InvitationMapper {
+
+    public static StoredInvitationInformation toStoredInvitationInformation(
+            InvitationInformation invitationInformation) {
+        String expiration = String.valueOf(
+                Date.from(Instant.now().plusSeconds(invitationInformation.getTimeToLive())));
+
+        return new StoredInvitationInformation(invitationInformation.getPetId(),
+                invitationInformation.getUserId(), expiration);
+    }
+}

--- a/be/src/main/java/buddyguard/mybuddyguard/invitation/repository/InvitationRepository.java
+++ b/be/src/main/java/buddyguard/mybuddyguard/invitation/repository/InvitationRepository.java
@@ -54,6 +54,17 @@ public class InvitationRepository {
     }
 
     /**
+     * 초대링크 정보를 조회 후 바로 삭제합니다.
+     *
+     * @param uuid
+     * @return
+     */
+    public Optional<StoredInvitationInformation> getAndDelete(String uuid) {
+        String key = makeKey(uuid);
+        return Optional.ofNullable(redisTemplate.opsForValue().getAndDelete(key));
+    }
+
+    /**
      * uuid 값과 키스페이스 값을 합쳐 key를 생성합니다.
      *
      * @param uuid

--- a/be/src/main/java/buddyguard/mybuddyguard/invitation/repository/InvitationRepository.java
+++ b/be/src/main/java/buddyguard/mybuddyguard/invitation/repository/InvitationRepository.java
@@ -1,6 +1,8 @@
 package buddyguard.mybuddyguard.invitation.repository;
 
 import buddyguard.mybuddyguard.invitation.entity.InvitationInformation;
+import buddyguard.mybuddyguard.invitation.mapper.InvitationMapper;
+import buddyguard.mybuddyguard.invitation.repository.dto.StoredInvitationInformation;
 import java.util.Optional;
 import java.util.concurrent.TimeUnit;
 import org.springframework.data.redis.core.RedisTemplate;
@@ -9,9 +11,9 @@ import org.springframework.stereotype.Repository;
 @Repository
 public class InvitationRepository {
 
-    private final RedisTemplate<String, InvitationInformation> redisTemplate;
+    private final RedisTemplate<String, StoredInvitationInformation> redisTemplate;
 
-    public InvitationRepository(RedisTemplate<String, InvitationInformation> redisTemplate) {
+    public InvitationRepository(RedisTemplate<String, StoredInvitationInformation> redisTemplate) {
         this.redisTemplate = redisTemplate;
     }
 
@@ -23,7 +25,8 @@ public class InvitationRepository {
     public void save(InvitationInformation invitationInformation) {
         String key = makeKey(invitationInformation.getId());
         redisTemplate.opsForValue()
-                .set(key, invitationInformation, invitationInformation.getTimeToLive(),
+                .set(key, InvitationMapper.toStoredInvitationInformation(invitationInformation),
+                        invitationInformation.getTimeToLive(),
                         TimeUnit.SECONDS);
     }
 
@@ -33,11 +36,11 @@ public class InvitationRepository {
      * @param uuid
      * @return
      */
-    public Optional<InvitationInformation> findById(String uuid) {
+    public Optional<StoredInvitationInformation> findById(String uuid) {
         String key = makeKey(uuid);
-        InvitationInformation invitationInformation = redisTemplate.opsForValue()
+        StoredInvitationInformation storedInvitationInformation = redisTemplate.opsForValue()
                 .get(key);
-        return Optional.ofNullable(invitationInformation);
+        return Optional.ofNullable(storedInvitationInformation);
     }
 
     /**
@@ -52,6 +55,7 @@ public class InvitationRepository {
 
     /**
      * uuid 값과 키스페이스 값을 합쳐 key를 생성합니다.
+     *
      * @param uuid
      * @return
      */

--- a/be/src/main/java/buddyguard/mybuddyguard/invitation/repository/InvitationRepository.java
+++ b/be/src/main/java/buddyguard/mybuddyguard/invitation/repository/InvitationRepository.java
@@ -1,10 +1,61 @@
 package buddyguard.mybuddyguard.invitation.repository;
 
 import buddyguard.mybuddyguard.invitation.entity.InvitationInformation;
-import org.springframework.data.keyvalue.repository.KeyValueRepository;
+import java.util.Optional;
+import java.util.concurrent.TimeUnit;
+import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.stereotype.Repository;
 
 @Repository
-public interface InvitationRepository extends KeyValueRepository<InvitationInformation, String> {
-    boolean existsById(String id);
+public class InvitationRepository {
+
+    private final RedisTemplate<String, InvitationInformation> redisTemplate;
+
+    public InvitationRepository(RedisTemplate<String, InvitationInformation> redisTemplate) {
+        this.redisTemplate = redisTemplate;
+    }
+
+    /**
+     * 초대링크 정보를 저장합니다. 저장 시 객체의 TTL값에 따라 만료가 설정됩니다.
+     *
+     * @param invitationInformation
+     */
+    public void save(InvitationInformation invitationInformation) {
+        String key = makeKey(invitationInformation.getId());
+        redisTemplate.opsForValue()
+                .set(key, invitationInformation, invitationInformation.getTimeToLive(),
+                        TimeUnit.SECONDS);
+    }
+
+    /**
+     * uuid를 이용해 해당 초대링크 정보를 찾아서 반환합니다.
+     *
+     * @param uuid
+     * @return
+     */
+    public Optional<InvitationInformation> findById(String uuid) {
+        String key = makeKey(uuid);
+        InvitationInformation invitationInformation = redisTemplate.opsForValue()
+                .get(key);
+        return Optional.ofNullable(invitationInformation);
+    }
+
+    /**
+     * uuid를 이용해 해당 초대링크 정보를 삭제합니다.
+     *
+     * @param uuid
+     */
+    public void delete(String uuid) {
+        String key = makeKey(uuid);
+        redisTemplate.delete(key);
+    }
+
+    /**
+     * uuid 값과 키스페이스 값을 합쳐 key를 생성합니다.
+     * @param uuid
+     * @return
+     */
+    private String makeKey(String uuid) {
+        return "invitation:" + uuid;
+    }
 }

--- a/be/src/main/java/buddyguard/mybuddyguard/invitation/repository/dto/StoredInvitationInformation.java
+++ b/be/src/main/java/buddyguard/mybuddyguard/invitation/repository/dto/StoredInvitationInformation.java
@@ -1,0 +1,6 @@
+package buddyguard.mybuddyguard.invitation.repository.dto;
+
+public record StoredInvitationInformation(Long petId,
+                                          Long userId,
+                                          String expiration) {
+}

--- a/be/src/main/java/buddyguard/mybuddyguard/invitation/service/InvitationService.java
+++ b/be/src/main/java/buddyguard/mybuddyguard/invitation/service/InvitationService.java
@@ -70,6 +70,9 @@ public class InvitationService {
                 .pet(pet)
                 .role(UserPetRole.GUEST).build();
         userPetRepository.save(userPet);
+
+        // 종료하고 해당 링크 삭제하기 (링크는 1회용이다)
+        invitationRepository.delete(uuid);
     }
 
     private void validateInvitation(Long userId, Long petId) {

--- a/be/src/main/java/buddyguard/mybuddyguard/invitation/service/InvitationService.java
+++ b/be/src/main/java/buddyguard/mybuddyguard/invitation/service/InvitationService.java
@@ -43,8 +43,8 @@ public class InvitationService {
 
         String uuid = InvitationLinkGenerator.generateUuid().toString();
 
-        InvitationInformation invitationInformation = InvitationInformation.builder().id(uuid)
-                .userId(userId).petId(petId).build();
+        InvitationInformation invitationInformation = InvitationInformation.create(uuid, petId,
+                userId);
 
         invitationRepository.save(invitationInformation);
 

--- a/be/src/main/java/buddyguard/mybuddyguard/invitation/service/InvitationService.java
+++ b/be/src/main/java/buddyguard/mybuddyguard/invitation/service/InvitationService.java
@@ -10,6 +10,7 @@ import buddyguard.mybuddyguard.invitation.entity.InvitationInformation;
 import buddyguard.mybuddyguard.invitation.exception.InvitationLinkExpiredException;
 import buddyguard.mybuddyguard.invitation.exception.UserPetGroupNotFound;
 import buddyguard.mybuddyguard.invitation.repository.InvitationRepository;
+import buddyguard.mybuddyguard.invitation.repository.dto.StoredInvitationInformation;
 import buddyguard.mybuddyguard.invitation.utils.InvitationLinkGenerator;
 import buddyguard.mybuddyguard.login.entity.Users;
 import buddyguard.mybuddyguard.login.repository.UserRepository;

--- a/be/src/main/java/buddyguard/mybuddyguard/invitation/service/InvitationService.java
+++ b/be/src/main/java/buddyguard/mybuddyguard/invitation/service/InvitationService.java
@@ -58,8 +58,8 @@ public class InvitationService {
         Users user = userRepository.findById(userId)
                 .orElseThrow(UserInformationNotFoundException::new);
 
-        StoredInvitationInformation invitation = invitationRepository.findById(uuid).orElseThrow(
-                InvitationLinkExpiredException::new);
+        StoredInvitationInformation invitation = invitationRepository.getAndDelete(uuid)
+                .orElseThrow(InvitationLinkExpiredException::new);
 
         Pet pet = petRepository.findById(invitation.petId())
                 .orElseThrow(PetNotFoundException::new);
@@ -71,9 +71,6 @@ public class InvitationService {
                 .pet(pet)
                 .role(UserPetRole.GUEST).build();
         userPetRepository.save(userPet);
-
-        // 종료하고 해당 링크 삭제하기 (링크는 1회용이다)
-        invitationRepository.delete(uuid);
     }
 
     private void validateInvitation(Long userId, Long petId) {

--- a/be/src/main/java/buddyguard/mybuddyguard/invitation/service/InvitationService.java
+++ b/be/src/main/java/buddyguard/mybuddyguard/invitation/service/InvitationService.java
@@ -57,10 +57,10 @@ public class InvitationService {
         Users user = userRepository.findById(userId)
                 .orElseThrow(UserInformationNotFoundException::new);
 
-        InvitationInformation invitation = invitationRepository.findById(uuid).orElseThrow(
+        StoredInvitationInformation invitation = invitationRepository.findById(uuid).orElseThrow(
                 InvitationLinkExpiredException::new);
 
-        Pet pet = petRepository.findById(invitation.getPetId())
+        Pet pet = petRepository.findById(invitation.petId())
                 .orElseThrow(PetNotFoundException::new);
 
         validateRegister(user.getId(), pet.getId());

--- a/be/src/main/java/buddyguard/mybuddyguard/jwt/entity/RefreshToken.java
+++ b/be/src/main/java/buddyguard/mybuddyguard/jwt/entity/RefreshToken.java
@@ -8,10 +8,7 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.springframework.data.annotation.Id;
-import org.springframework.data.redis.core.RedisHash;
-import org.springframework.data.redis.core.TimeToLive;
 
-@RedisHash(value = "refresh")
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
 @Getter
@@ -21,7 +18,6 @@ public class RefreshToken {
     private String token;
     private Long userId;
     private String expiration;
-    @TimeToLive
     private Long timeToLive;
 
     public static RefreshToken create(Long id, String token, Long timeToLive) {

--- a/be/src/main/java/buddyguard/mybuddyguard/jwt/entity/RefreshToken.java
+++ b/be/src/main/java/buddyguard/mybuddyguard/jwt/entity/RefreshToken.java
@@ -1,5 +1,7 @@
 package buddyguard.mybuddyguard.jwt.entity;
 
+import java.time.Instant;
+import java.util.Date;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -7,8 +9,9 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.springframework.data.annotation.Id;
 import org.springframework.data.redis.core.RedisHash;
+import org.springframework.data.redis.core.TimeToLive;
 
-@RedisHash(value = "refresh", timeToLive = 7 * 24 * 60 * 60L)
+@RedisHash(value = "refresh")
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
 @Getter
@@ -18,4 +21,15 @@ public class RefreshToken {
     private String token;
     private Long userId;
     private String expiration;
+    @TimeToLive
+    private Long timeToLive;
+
+    public static RefreshToken create(Long id, String token, Long timeToLive) {
+        return RefreshToken.builder()
+                .userId(id)
+                .token(token)
+                .expiration(String.valueOf(Date.from(Instant.now().plusSeconds(timeToLive))))
+                .timeToLive(timeToLive)
+                .build();
+    }
 }

--- a/be/src/main/java/buddyguard/mybuddyguard/jwt/mapper/RefreshTokenMapper.java
+++ b/be/src/main/java/buddyguard/mybuddyguard/jwt/mapper/RefreshTokenMapper.java
@@ -1,0 +1,11 @@
+package buddyguard.mybuddyguard.jwt.mapper;
+
+import buddyguard.mybuddyguard.jwt.entity.RefreshToken;
+import buddyguard.mybuddyguard.jwt.repository.dto.StoredRefreshToken;
+
+
+public class RefreshTokenMapper {
+    public static StoredRefreshToken toStoredRefreshToken(RefreshToken refreshToken) {
+        return new StoredRefreshToken(refreshToken.getUserId(), refreshToken.getExpiration());
+    }
+}

--- a/be/src/main/java/buddyguard/mybuddyguard/jwt/repository/RefreshTokenRepository.java
+++ b/be/src/main/java/buddyguard/mybuddyguard/jwt/repository/RefreshTokenRepository.java
@@ -1,10 +1,71 @@
 package buddyguard.mybuddyguard.jwt.repository;
 
 import buddyguard.mybuddyguard.jwt.entity.RefreshToken;
-import org.springframework.data.keyvalue.repository.KeyValueRepository;
+import java.util.Optional;
+import java.util.concurrent.TimeUnit;
+import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.stereotype.Repository;
 
 @Repository
-public interface RefreshTokenRepository extends KeyValueRepository<RefreshToken, String> {
+public class RefreshTokenRepository {
 
+    private final RedisTemplate<String, Object> redisTemplate;
+
+    public RefreshTokenRepository(RedisTemplate<String, Object> redisTemplate) {
+        this.redisTemplate = redisTemplate;
+    }
+
+    /**
+     * Refresh 토큰 저장
+     *
+     * @param refreshToken
+     */
+    public void save(RefreshToken refreshToken) {
+        String key = makeKey(refreshToken.getToken());
+        redisTemplate.opsForValue()
+                .set(key, refreshToken, refreshToken.getTimeToLive(), TimeUnit.SECONDS);
+    }
+
+    /**
+     * Refresh 토큰을 조회합니다.
+     *
+     * @param token
+     * @return
+     */
+    public Optional<RefreshToken> findByToken(String token) {
+        String key = makeKey(token);
+        RefreshToken refreshToken = (RefreshToken) redisTemplate.opsForValue().get(key);
+        return Optional.ofNullable(refreshToken);
+    }
+
+    /**
+     * Refresh 토큰을 삭제합니다.
+     *
+     * @param token
+     */
+    public void deleteById(String token) {
+        String key = makeKey(token);
+        redisTemplate.delete(key);
+    }
+
+    /**
+     * Refresh 토큰이 존재하는지 확인합니다.
+     *
+     * @param token
+     * @return
+     */
+    public boolean existsById(String token) {
+        String key = makeKey(token);
+        return Boolean.TRUE.equals(redisTemplate.hasKey(key));
+    }
+
+    /**
+     * 토큰 값과 키스페이스 값을 합쳐 key를 생성합니다.
+     *
+     * @param token
+     * @return
+     */
+    private String makeKey(String token) {
+        return "refresh:" + token;
+    }
 }

--- a/be/src/main/java/buddyguard/mybuddyguard/jwt/repository/RefreshTokenRepository.java
+++ b/be/src/main/java/buddyguard/mybuddyguard/jwt/repository/RefreshTokenRepository.java
@@ -1,6 +1,8 @@
 package buddyguard.mybuddyguard.jwt.repository;
 
 import buddyguard.mybuddyguard.jwt.entity.RefreshToken;
+import buddyguard.mybuddyguard.jwt.mapper.RefreshTokenMapper;
+import buddyguard.mybuddyguard.jwt.repository.dto.StoredRefreshToken;
 import java.util.Optional;
 import java.util.concurrent.TimeUnit;
 import org.springframework.data.redis.core.RedisTemplate;
@@ -23,7 +25,8 @@ public class RefreshTokenRepository {
     public void save(RefreshToken refreshToken) {
         String key = makeKey(refreshToken.getToken());
         redisTemplate.opsForValue()
-                .set(key, refreshToken, refreshToken.getTimeToLive(), TimeUnit.SECONDS);
+                .set(key, RefreshTokenMapper.toStoredRefreshToken(refreshToken),
+                        refreshToken.getTimeToLive(), TimeUnit.SECONDS);
     }
 
     /**
@@ -32,9 +35,9 @@ public class RefreshTokenRepository {
      * @param token
      * @return
      */
-    public Optional<RefreshToken> findByToken(String token) {
+    public Optional<StoredRefreshToken> findByToken(String token) {
         String key = makeKey(token);
-        RefreshToken refreshToken = (RefreshToken) redisTemplate.opsForValue().get(key);
+        StoredRefreshToken refreshToken = (StoredRefreshToken) redisTemplate.opsForValue().get(key);
         return Optional.ofNullable(refreshToken);
     }
 

--- a/be/src/main/java/buddyguard/mybuddyguard/jwt/repository/dto/StoredRefreshToken.java
+++ b/be/src/main/java/buddyguard/mybuddyguard/jwt/repository/dto/StoredRefreshToken.java
@@ -1,0 +1,7 @@
+package buddyguard.mybuddyguard.jwt.repository.dto;
+
+public record StoredRefreshToken(
+        long userId,
+        String expiration) {
+
+}

--- a/be/src/main/java/buddyguard/mybuddyguard/login/handler/CustomSuccessHandler.java
+++ b/be/src/main/java/buddyguard/mybuddyguard/login/handler/CustomSuccessHandler.java
@@ -30,6 +30,8 @@ public class CustomSuccessHandler extends SimpleUrlAuthenticationSuccessHandler 
 
     private final TokenService tokenService;
     private final RefreshTokenRepository refreshTokenRepository;
+    private static final long REFRESH_TOKEN_EXPIRATION_SECONDS = 7 * 24 * 60 * 60L;
+    private static final String REDIRACTION_URL = "https://buddyguard.site/";
 
     public CustomSuccessHandler(TokenService tokenService, RefreshTokenRepository refreshTokenRepository) {
         this.tokenService = tokenService;
@@ -51,16 +53,16 @@ public class CustomSuccessHandler extends SimpleUrlAuthenticationSuccessHandler 
         String role = authority.getAuthority();
 
         String refreshToken = tokenService.createJwt(userId, role, TokenType.REFRESH,
-                7 * 24 * 60 * 60L);
+                REFRESH_TOKEN_EXPIRATION_SECONDS);
 
         // refresh 토큰 저장
-        saveRefreshToken(userId, refreshToken, 7 * 24 * 60 * 60L);
+        saveRefreshToken(userId, refreshToken);
 
         // 쿠키에 토큰 저장
         response.addCookie(createCookie("refresh", refreshToken));
         response.setHeader(HttpHeaders.ACCESS_CONTROL_ALLOW_CREDENTIALS, "true");
 
-        response.sendRedirect("https://buddyguard.site/");
+        response.sendRedirect(REDIRACTION_URL);
     }
 
     /**
@@ -78,8 +80,8 @@ public class CustomSuccessHandler extends SimpleUrlAuthenticationSuccessHandler 
         return cookie;
     }
 
-    private void saveRefreshToken(Long userId, String refreshToken, Long expiredSeconds) {
-        RefreshToken token = RefreshToken.create(userId, refreshToken, expiredSeconds);
+    private void saveRefreshToken(Long userId, String refreshToken) {
+        RefreshToken token = RefreshToken.create(userId, refreshToken, REFRESH_TOKEN_EXPIRATION_SECONDS);
         refreshTokenRepository.save(token);
     }
 }

--- a/be/src/main/java/buddyguard/mybuddyguard/login/handler/CustomSuccessHandler.java
+++ b/be/src/main/java/buddyguard/mybuddyguard/login/handler/CustomSuccessHandler.java
@@ -29,11 +29,11 @@ import org.springframework.transaction.annotation.Transactional;
 public class CustomSuccessHandler extends SimpleUrlAuthenticationSuccessHandler {
 
     private final TokenService tokenService;
-    private final RefreshTokenRepository repository;
+    private final RefreshTokenRepository refreshTokenRepository;
 
-    public CustomSuccessHandler(TokenService tokenService, RefreshTokenRepository repository) {
+    public CustomSuccessHandler(TokenService tokenService, RefreshTokenRepository refreshTokenRepository) {
         this.tokenService = tokenService;
-        this.repository = repository;
+        this.refreshTokenRepository = refreshTokenRepository;
     }
 
     @Transactional
@@ -79,9 +79,7 @@ public class CustomSuccessHandler extends SimpleUrlAuthenticationSuccessHandler 
     }
 
     private void saveRefreshToken(Long userId, String refreshToken, Long expiredSeconds) {
-        RefreshToken token = RefreshToken.builder().userId(userId).token(refreshToken)
-                .expiration(String.valueOf(Date.from(Instant.now().plusSeconds(expiredSeconds))))
-                .build();
-        repository.save(token);
+        RefreshToken token = RefreshToken.create(userId, refreshToken, expiredSeconds);
+        refreshTokenRepository.save(token);
     }
 }


### PR DESCRIPTION
## 연관 이슈
#1 , #2 , #3 , #4 , #5 
## 작업 내용
1. refresh token 저장 과정에서 생기는 Redis의 불필요한 메모리 점유 현상 해결
    - 인덱스 데이터 생성되지 않도록 `Repository` 쿼리 메소드 방식에서 `RedisTemplate`에서 직접 명령을 날리도록 수정
    - 토큰 TTL 시간 조정 가능하도록 수정
    - 토큰 저장 시, 원하는 값만 저장하도록 DB 계층과의 작업에서 사용할 dto 추가
2. `Spring Data Redis`의 `Repository`에서 `RedisTemplate`으로 변경 작업
    - `invitation`에서도 `RedisTemplate` 사용하도록 변경
3. 초대 링크 가입 로직에서 하나의 링크로 여러 명의 유저가 가입되는 동시성 문제 해결
    - 나누어져 있던 조회와 삭제 작업을 `GETDEL`을 사용하도록 변경
4. 초대 링크 가입 로직에서 예외 발생 시 Redis 작업이 롤백되지 않는 문제 발생
    - 명시적으로 Redis 트랜잭션 활성화하는 옵션 추가