### PR TITLE
Redis 트랜잭션 적용 이후로 초대링크 값이 null로 조회되는 문제 해결

### DIFF
--- a/be/build.gradle
+++ b/be/build.gradle
@@ -80,6 +80,8 @@ dependencies {
 
     // prometheus
     runtimeOnly 'io.micrometer:micrometer-registry-prometheus'
+
+    implementation 'org.redisson:redisson:3.43.0'
 }
 
 jar {

--- a/be/src/main/java/buddyguard/mybuddyguard/config/RedisConfig.java
+++ b/be/src/main/java/buddyguard/mybuddyguard/config/RedisConfig.java
@@ -63,7 +63,6 @@ public class RedisConfig {
 
         redisTemplate.setKeySerializer(new StringRedisSerializer());
         redisTemplate.setValueSerializer(serializer);
-        redisTemplate.setEnableTransactionSupport(true);
 
         return redisTemplate;
     }

--- a/be/src/main/java/buddyguard/mybuddyguard/invitation/repository/InvitationRepository.java
+++ b/be/src/main/java/buddyguard/mybuddyguard/invitation/repository/InvitationRepository.java
@@ -43,15 +43,6 @@ public class InvitationRepository {
         return Optional.ofNullable(storedInvitationInformation);
     }
 
-    /**
-     * uuid를 이용해 해당 초대링크 정보를 삭제합니다.
-     *
-     * @param uuid
-     */
-    public void delete(String uuid) {
-        String key = makeKey(uuid);
-        redisTemplate.delete(key);
-    }
 
     /**
      * 초대링크 정보를 조회 후 바로 삭제합니다.

--- a/be/src/main/java/buddyguard/mybuddyguard/invitation/repository/InvitationRepository.java
+++ b/be/src/main/java/buddyguard/mybuddyguard/invitation/repository/InvitationRepository.java
@@ -55,6 +55,13 @@ public class InvitationRepository {
         return Optional.ofNullable(redisTemplate.opsForValue().getAndDelete(key));
     }
 
+    /**
+     * 삭제된 초대링크를 복구합니다.
+     * 트랜잭션 롤백 시 사용됩니다.
+     *
+     * @param uuid
+     * @param target
+     */
     public void restore(String uuid, StoredInvitationInformation target) {
         String key = makeKey(uuid);
         redisTemplate.opsForValue().set(key, target, 3600L, TimeUnit.SECONDS);

--- a/be/src/main/java/buddyguard/mybuddyguard/invitation/repository/InvitationRepository.java
+++ b/be/src/main/java/buddyguard/mybuddyguard/invitation/repository/InvitationRepository.java
@@ -3,6 +3,7 @@ package buddyguard.mybuddyguard.invitation.repository;
 import buddyguard.mybuddyguard.invitation.entity.InvitationInformation;
 import buddyguard.mybuddyguard.invitation.mapper.InvitationMapper;
 import buddyguard.mybuddyguard.invitation.repository.dto.StoredInvitationInformation;
+import buddyguard.mybuddyguard.invitation.utils.SecondConverter;
 import java.util.Optional;
 import java.util.concurrent.TimeUnit;
 import org.springframework.data.redis.core.RedisTemplate;
@@ -64,7 +65,8 @@ public class InvitationRepository {
      */
     public void restore(String uuid, StoredInvitationInformation target) {
         String key = makeKey(uuid);
-        redisTemplate.opsForValue().set(key, target, 3600L, TimeUnit.SECONDS);
+        long leftTtl = SecondConverter.stringToLong(target.expiration());
+        redisTemplate.opsForValue().set(key, target, leftTtl, TimeUnit.SECONDS);
     }
 
     /**

--- a/be/src/main/java/buddyguard/mybuddyguard/invitation/repository/InvitationRepository.java
+++ b/be/src/main/java/buddyguard/mybuddyguard/invitation/repository/InvitationRepository.java
@@ -55,6 +55,11 @@ public class InvitationRepository {
         return Optional.ofNullable(redisTemplate.opsForValue().getAndDelete(key));
     }
 
+    public void restore(String uuid, StoredInvitationInformation target) {
+        String key = makeKey(uuid);
+        redisTemplate.opsForValue().set(key, target, 3600L, TimeUnit.SECONDS);
+    }
+
     /**
      * uuid 값과 키스페이스 값을 합쳐 key를 생성합니다.
      *

--- a/be/src/main/java/buddyguard/mybuddyguard/invitation/utils/SecondConverter.java
+++ b/be/src/main/java/buddyguard/mybuddyguard/invitation/utils/SecondConverter.java
@@ -1,0 +1,22 @@
+package buddyguard.mybuddyguard.invitation.utils;
+
+import java.time.Duration;
+import java.time.ZonedDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.Locale;
+
+public class SecondConverter {
+
+    public static Long stringToLong(String expirationString) {
+
+        DateTimeFormatter formatter = DateTimeFormatter.ofPattern("EEE MMM dd HH:mm:ss z yyyy",
+                Locale.ENGLISH);
+
+        ZonedDateTime expirationDate = ZonedDateTime.parse(expirationString, formatter);
+
+        ZonedDateTime now = ZonedDateTime.now(expirationDate.getZone());
+
+        long leftSeconds = Duration.between(now, expirationDate).getSeconds();
+        return Math.max(leftSeconds, 0);
+    }
+}


### PR DESCRIPTION
## 연관 이슈
#7 

## 작업 내용
1. Redis 트랜잭션 적용 이후로 초대링크 값이 null로 조회되는 문제 해결
    - Redis 트랜잭션 다시 비활성화
    - `TransactionSynchronizationManager`과 `TransactionSynchronization`을 사용하여 예외 발생하면 삭제한 값을 복구하도록 구조 변경